### PR TITLE
rgl.* changed to *3d

### DIFF
--- a/R/plot3d.r
+++ b/R/plot3d.r
@@ -89,7 +89,7 @@ setMethod('plot3d', signature(x = 'Profile'),
             y <- m * dx + n
             
             # plot 3D
-            rgl.bg(color = 'white')
+            bg3d(color = 'white')
             points3d(
               y,
               x@processedData@pointsWithTopo$height,
@@ -98,8 +98,8 @@ setMethod('plot3d', signature(x = 'Profile'),
               size = psize,
               ...
             )
-            rgl.bbox()
-            rgl.texts(
+            bbox3d()
+            text3d(
               y[1],
               x@processedData@pointsWithTopo$height[1] + 20,
               dx[1],


### PR DESCRIPTION
Some upcoming changes to the rgl package will require changes to geoelectrics.
I will be deprecating a number of rgl.* function calls.  You can read
about the issues here:

    https://dmurdoch.github.io/rgl/articles/deprecation.html

I have made the required changes to geoelectrics in the attached patch.
These changes should work with both old and new rgl versions.